### PR TITLE
fix: ensure currentColor is used as default fill

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -143,7 +143,7 @@ Icon.propTypes = {
 
 Icon.defaultProps = {
   size: null,
-  color: null,
+  color: 'currentColor',
   horizontal: false,
   vertical: false,
   rotate: 0,

--- a/tests/Icon.spec.tsx
+++ b/tests/Icon.spec.tsx
@@ -49,7 +49,7 @@ describe("<Icon path={path} />", () => {
   it("verify svg > path.style.fill", () => {
     const svgElement = shallow(<Icon path={path} />);
     const { style } = svgElement.childAt(0).props();
-    expect(style.fill).to.equal(undefined);
+    expect(style.fill).to.equal('currentColor');
   });
 
 });

--- a/tests/Stack.spec.tsx
+++ b/tests/Stack.spec.tsx
@@ -28,7 +28,7 @@ describe("<Stack><Icon path={path} /></Stack> Renders", () => {
     expect(iconEle.type()).to.equal('path');
     expect(iconComponent.prop('path')).to.equal(path);
     expect(iconComponent.prop('size')).to.equal(null);
-    expect(iconComponent.prop('color')).to.equal(null);
+    expect(iconComponent.prop('color')).to.equal('currentColor');
     expect(iconComponent.prop('horizontal')).to.equal(false);
     expect(iconComponent.prop('vertical')).to.equal(false);
     expect(iconComponent.prop('rotate')).to.equal(0);


### PR DESCRIPTION
Previously, the default props for Icon set `color` as null, which meant the previous change to set the default as `fill: currentColor` in ec665ec wasn't effective and the inline style attribute remained empty.

This also updates the unit tests to confirm the value is passed through to the underlying `path.style.fill`.

The demo at https://templarian.github.io/@mdi/react/ has an example that looks like this, when rendered:

```html
<span style="fill: pink;"><svg viewBox="0 0 24 24" role="presentation"><path d="[snip]"></path></svg></span>
```

The icon was appearing as pink, but only the `fill` style was being applied outside the icon.  By comparison, the path needs to look like `<path d="[snip] style="fill: currentColor">` and the outer `<span>` changed to `<span style="color: pink;">` to the text colour is picked up ([CSS ref](https://www.w3.org/TR/css-color-3/#currentcolor))

Corresponding demo change PR at https://github.com/Templarian/MaterialDesign-React-Demo/pull/6