### PR TITLE
Expose `id` prop for customizing label id

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -5,10 +5,11 @@ import { IconProps } from './IconProps';
 
 export { default as Stack } from './Stack';
 
-let id = 0;
+let idCounter = 0;
 
 export const Icon: FunctionComponent<IconProps> = React.forwardRef<SVGSVGElement, IconProps>(({
   path,
+  id = ++idCounter,
   title = null,
   description = null,
   size = null,
@@ -21,7 +22,6 @@ export const Icon: FunctionComponent<IconProps> = React.forwardRef<SVGSVGElement
   inStack = false,
   ...rest
 }, ref) => {
-  id++;
   const pathStyle: any = {};
   const transform = [];
   if (size !== null) {

--- a/src/IconProps.ts
+++ b/src/IconProps.ts
@@ -5,6 +5,7 @@ export interface HTMLProps extends AriaAttributes {
 }
 
 export interface IconProps extends HTMLProps {
+  id?: string;
   path: string;
   ref?: RefObject<SVGSVGElement>;
   title?: string | null;

--- a/tests/Icon.spec.tsx
+++ b/tests/Icon.spec.tsx
@@ -219,6 +219,12 @@ describe("<Icon /> A11y", () => {
     expect(ariaLabelledby).to.equal('icon_labelledby_ icon_describedby_');
   });
 
+  it("id appended to aria-labelledby", () => {
+    const svgElement = shallow(<Icon path={path} title={'Foo'} description={'Bar'} id="hello" />);
+    const ariaLabelledby = svgElement.prop('aria-labelledby');
+    expect(ariaLabelledby).to.equal('icon_labelledby_hello icon_describedby_hello');
+  });
+
   it("title sets title", () => {
     const svgElement = shallow(<Icon path={path} title={'Foo'} />);
     const titleElement = svgElement.find('title');


### PR DESCRIPTION
Falls back to `idCounter` if no id provided. `++` goes first to maintain current
behavior (1 is the first id).

Fixes #50.